### PR TITLE
Task 9 - delete comment - tests, implementation, endpoint description

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -123,6 +123,20 @@
 - [x] Add a description of this endpoint
 
 
+# Task 9 - CORE: DELETE /api/comments/:comment_id
+- Integration tests for endpoint `DELETE /api/comments/:comment_id`
+    - [x] Responds with 204 status and no content if deleting was successful 
+    - [x] Responds with 404 error when comment_id is number but does not exist 
+    - [x] Responds with 400 error if comment_id (INT) is out of range
+    - [x] Responds with 400 error when comment_id not a number
+- Implementation
+    - [x] Route
+    - [x] Controller
+    - [x] Model
+- [x] Passing tests
+- [x] Add a description of this endpoint
+
+
 # Bugs
 - Psql pg-format timezone bug
     - [ ] Create PoC test

--- a/src/app.js
+++ b/src/app.js
@@ -23,6 +23,7 @@ app.use(express.json());
 require('./routes/api-v1/topics');
 require('./routes/api-v1/api');
 require('./routes/api-v1/articles');
+require('./routes/api-v1/comments');
 
 
 // Errors

--- a/src/controllers/delete-comment.js
+++ b/src/controllers/delete-comment.js
@@ -1,0 +1,23 @@
+const removeComment = require('../models/remove-comment');
+const AppError = require('../errors/app-error');
+
+
+const deleteComment = async (req, res, next) => {
+    try {
+        const { comment_id } = req.params;
+
+        const comment = await removeComment(comment_id);
+
+        if(comment === undefined) {
+            next(new AppError({ code: 404, msg: '404 Not Found' }));
+            return;
+        }
+
+        res.status(204).send();
+    } catch (error) {
+        next(error);
+    }
+};
+
+
+module.exports = deleteComment;

--- a/src/models/remove-comment.js
+++ b/src/models/remove-comment.js
@@ -1,0 +1,25 @@
+const db = require('../db/connection');
+const ModelError = require('./errors/model-error');
+
+
+const removeComment = async (commentId) => {
+    try {
+        const { rows } = await db.query(
+            `DELETE FROM
+                    comments
+                WHERE
+                    comment_id = $1
+                RETURNING
+                    comment_id
+            ;`,
+            [commentId]
+        );
+        return rows[0];
+    } catch (error) {
+        const modelErr = new ModelError({ psql: error, msg: 'PSQL Error' });
+        throw modelErr.toAppError();
+    }
+};
+
+
+module.exports = removeComment;

--- a/src/routes/api-v1/comments.js
+++ b/src/routes/api-v1/comments.js
@@ -1,0 +1,4 @@
+const app = require('../../app');
+
+
+app.delete('/api/comments/:comment_id', require('../../controllers/delete-comment'));

--- a/src/routes/api-v1/endpoints.json
+++ b/src/routes/api-v1/endpoints.json
@@ -83,5 +83,10 @@
         "article_img_url": "https://images.pexels.com/photos/158651/news-newsletter-newspaper-information-158651.jpeg?w=700&h=700"
       }
     }
+  },
+  "CORE: DELETE /api/comments/:comment_id": {
+    "description": "deletes the given comment by comment_id with status 204 and no content",
+    "queries": [],
+    "exampleResponse": ""
   }
 }

--- a/tests/integration/api-v1/comments.test.js
+++ b/tests/integration/api-v1/comments.test.js
@@ -1,0 +1,56 @@
+const db = require('../../../src/db/connection');
+const app = require('../../../src/app');
+const request = require('supertest');
+const seed = require('../../../src/db/seeds/seed');
+const testData = require('../../../src/db/data/test-data/index');
+const AppError = require('../../../src/errors/app-error');
+
+
+beforeEach(() => {
+    return seed(testData);
+});
+
+afterAll(() => {
+    return db.end();
+});
+
+
+const createError404 = () => new AppError({ code: 404, msg: '404 Not Found', log: false }).exportForClient();
+const createError400 = () => new AppError({ code: 400, msg: '400 Bad Request', log: false }).exportForClient();
+
+
+describe("DELETE /api/comments/:comment_id", () => {
+
+    test("responds with 204 status and no content if deleting was successful", () => {
+        return request(app).delete('/api/comments/1')
+            .expect(204)
+            .then(({ body }) => {
+                expect(body).toEqual({});
+            })
+            .then(() => {
+                // Checking that we do not have this resource immediately after deletion
+                return request(app).delete('/api/comments/1')
+                    .expect(404)
+                    .then(({ body: { error } }) => { expect({ error }).toMatchObject(createError404()); });
+            })
+    });
+
+    test("responds with 404 error when comment_id is number but does not exist", () => {
+        return request(app).delete('/api/comments/333')
+            .expect(404)
+            .then(({ body: { error } }) => { expect({ error }).toMatchObject(createError404()); });
+    });
+
+    test("responds with 400 error if comment_id (INT) is out of range", () => {
+        return request(app).delete('/api/comments/' + (0x7FFFFFFF + 1))
+            .expect(400)
+            .then(({ body: { error } }) => { expect({ error }).toMatchObject(createError400()); });
+    });
+
+    test("responds with 400 error when comment_id not a number", () => {
+        return request(app).delete('/api/comments/not_a_number')
+            .expect(400)
+            .then(({ body: { error } }) => { expect({ error }).toMatchObject(createError400()); });
+    });
+
+});


### PR DESCRIPTION
# Task 9 - CORE: DELETE /api/comments/:comment_id
- Integration tests for endpoint `DELETE /api/comments/:comment_id`
    - [x] Responds with 204 status and no content if deleting was successful 
    - [x] Responds with 404 error when comment_id is number but does not exist 
    - [x] Responds with 400 error if comment_id (INT) is out of range
    - [x] Responds with 400 error when comment_id not a number
- Implementation
    - [x] Route
    - [x] Controller
    - [x] Model
- [x] Passing tests
- [x] Add a description of this endpoint